### PR TITLE
Add fix for CVE-2024-57077

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,6 +28,14 @@ function extend(target, source) {
   var value;
 
   for (var key in source) {
+    if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+      continue;
+    }
+
+    if (!Object.prototype.hasOwnProperty.call(source, key)) {
+      continue;
+    }
+
     value = source[key];
 
     if (Array.isArray(value)) {

--- a/test/extend.js
+++ b/test/extend.js
@@ -51,4 +51,13 @@ describe('extend', function() {
       ]
     });
   });
+
+  it('should not pollute Object.prototype', function() {
+    var target = {};
+    var source = JSON.parse('{"__proto__": {"polluted": "yes"}}');
+
+    util.extend(target, source);
+
+    assert.strictEqual(Object.prototype.polluted, undefined);
+  });
 });


### PR DESCRIPTION
This PR fixes a critical vulnerability (CVE-2024-57077) by blocking prototype pollution attempts in the extend function. It adds a continue statement inside the hasOwnProperty check to ensure only direct properties of source are copied to target.

### Details

| **Field**              | **Description**                                                                                                                                          |
|------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
| **CVE ID**             | CVE-2024-57077                                                                                       |
| **Severity**           | Critical                                                                                                                                                     |
| **Summary**            | The latest version of utils-extend (1.0.8) is vulnerable to Prototype Pollution through the entry function(s)</br> lib.extend. An attacker can supply a payload with Object.prototype setter to introduce </br>or modify properties within the global prototype chain, causing denial of service (DoS) |
